### PR TITLE
release: v0.2.0 — first signed release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ Versioning: [Semantic Versioning](https://semver.org/).
 
 <!-- PRs add entries here. Released versions move them to a versioned section. -->
 
+## [0.2.0] - 2026-04-04
+
 ### Added
 - SLSA Level 2 provenance attestation in release workflow — slsa-github-generator
   generic workflow generates an `.intoto.jsonl` attestation for the chart tgz

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: clusterfactory
 description: One helm install. Vanilla upstream Gitea + Jenkins — hello-world pipeline and Gitea Actions pre-wired.
-version: 0.1.8
+version: 0.2.0
 appVersion: "1.0.0"
 dependencies:
   - name: gitea

--- a/values.yaml
+++ b/values.yaml
@@ -6,7 +6,7 @@
 # Run: helm show values clusterfactory/clusterfactory | grep -A6 "^compatibility:"
 # ─────────────────────────────────────────────
 compatibility:
-  chart: "0.1.8"
+  chart: "0.2.0"
   gitea: "1.23.6"        # gitea subchart appVersion (gitea/gitea:11.0.1)
   jenkins: "2.541.3"     # jenkins subchart appVersion (jenkins/jenkins:5.9.9)
   actRunner: "0.3.1"     # gitea/act_runner image tag


### PR DESCRIPTION
Promotes the Unreleased changelog entries to [0.2.0] and bumps Chart.yaml + values.yaml.

**What's in this release:**
- CF-101: NetworkPolicy templates for default-deny clusters
- CF-102: SBOM generation (Syft SPDX JSON + cosign attestation)
- CF-103: SLSA Level 2 provenance (slsa-github-generator)
- Bug fixes from 0.1.8: ghost runner registrations, load.sh image source, --atomic deprecation

**After merging:** tag `v0.2.0` to trigger the release workflow.