### PR TITLE
ci: add release:published trigger for Scorecard Packaging check

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,6 +4,8 @@ on:
   push:
     tags:
       - 'v*'
+  release:
+    types: [published]
 
 # workflow-level: minimum possible
 # job-level permissions are declared explicitly per job below


### PR DESCRIPTION
Scorecard's Packaging check requires a workflow triggered by the `release` event to detect a publishing workflow. The existing `push: tags` trigger is not recognized. Adding `release: types: [published]` as an additional trigger satisfies the check.