### PR TITLE
fix: remove invalid 'administration' permission from scan.yaml

### DIFF
--- a/.github/workflows/scan.yaml
+++ b/.github/workflows/scan.yaml
@@ -64,7 +64,6 @@ jobs:
       id-token: write
       actions: read
       pull-requests: read
-      administration: read
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
         with:

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -13,3 +13,4 @@ dependencies:
 # Trigger test workflow
 
 
+


### PR DESCRIPTION
## Problem

The scan.yaml workflow is failing on all pushes with a workflow configuration error.

Root cause: The `administration: read` permission added in PR #24 is **not a valid GitHub Actions permission scope**.

Valid permissions are:
- actions, checks, contents, deployments, id-token
- issues, discussions, packages, pages, pull-requests
- repository-projects, security-events, statuses

## Solution

Remove the invalid `administration: read` permission from the Scorecard job.

## Note on Branch-Protection Check

The OSSF Scorecard Branch-Protection check shows `?` because it requires repository administration API access, which cannot be granted via workflow permissions. This requires either:
- A GitHub App with administration permissions, or
- A Personal Access Token (PAT) with admin scope

The default GITHUB_TOKEN does not have admin access by design (principle of least privilege).

## Testing

After merge, scan.yaml workflows should execute successfully instead of failing immediately.

Fixes workflow failures in runs:
- 24001950704 (latest main push)
- 24001544820 (helm-index PR)  
- 24001288157, 24001263883 (earlier main pushes)