### PR TITLE
chore: Bump version to 0.2.1

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: clusterfactory
 description: One helm install. Vanilla upstream Gitea + Jenkins — hello-world pipeline and Gitea Actions pre-wired.
-version: 0.2.0
+version: 0.2.1
 appVersion: "1.0.0"
 dependencies:
   - name: gitea


### PR DESCRIPTION
Bump chart version to 0.2.1 for release with deployment modes feature.

Previous v0.2.0 tag already exists from April 5th.