### PR TITLE
ci: Add Zarf package validation workflow

### DIFF
--- a/.github/workflows/zarf-test.yaml
+++ b/.github/workflows/zarf-test.yaml
@@ -1,0 +1,185 @@
+name: Zarf Package Tests
+
+on:
+  pull_request:
+    paths:
+      - 'zarf.yaml'
+      - 'platform.yaml'
+      - 'manifests/**'
+      - 'values/gitea.yaml'
+      - 'values/jenkins.yaml'
+      - 'engine/**'
+      - '.github/workflows/zarf-test.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'zarf.yaml'
+      - 'platform.yaml'
+      - 'manifests/**'
+      - 'values/gitea.yaml'
+      - 'values/jenkins.yaml'
+      - 'engine/**'
+      - '.github/workflows/zarf-test.yaml'
+
+# scorecard: restrict default token permissions to minimum required
+permissions:
+  contents: read
+
+jobs:
+  validate-package:
+    name: Validate Zarf package structure
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          pip install pyyaml jsonschema
+
+      - name: Validate package structure
+        run: python validate-package.py
+
+      - name: Validate zarf.yaml syntax
+        run: |
+          python -c "
+          import yaml
+          with open('zarf.yaml') as f:
+              zarf = yaml.safe_load(f)
+          assert 'kind' in zarf, 'Missing kind field'
+          assert zarf['kind'] == 'ZarfPackageConfig', 'Invalid kind'
+          assert 'metadata' in zarf, 'Missing metadata'
+          assert 'components' in zarf, 'Missing components'
+          print(f'✓ Valid Zarf package with {len(zarf[\"components\"])} components')
+          "
+
+      - name: Validate platform.yaml syntax
+        run: |
+          python -c "
+          import yaml
+          with open('platform.yaml') as f:
+              platform = yaml.safe_load(f)
+          assert 'components' in platform, 'Missing components'
+          print(f'✓ Valid platform spec with {len(platform[\"components\"])} components')
+          "
+
+      - name: Check for required manifests
+        run: |
+          for manifest in wire-job.yaml wire-rbac.yaml platform-configmap.yaml gitea-admin-secret.yaml networkpolicy.yaml; do
+            if [ ! -f "manifests/$manifest" ]; then
+              echo "✗ Missing manifest: $manifest"
+              exit 1
+            fi
+            echo "✓ Found manifest: $manifest"
+          done
+
+      - name: Validate Kubernetes manifests
+        run: |
+          for manifest in manifests/*.yaml; do
+            echo "Validating $manifest..."
+            python -c "
+          import yaml, sys
+          try:
+              with open('$manifest') as f:
+                  for doc in yaml.safe_load_all(f):
+                      if doc is None:
+                          continue
+                      assert 'apiVersion' in doc, 'Missing apiVersion'
+                      assert 'kind' in doc, 'Missing kind'
+                      print(f'  ✓ {doc[\"kind\"]} valid')
+          except Exception as e:
+              print(f'  ✗ Error: {e}')
+              sys.exit(1)
+          "
+          done
+
+  lint-wire-engine:
+    name: Lint wire engine code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Python
+        uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        working-directory: engine
+        run: |
+          pip install -e .
+          pip install pylint
+
+      - name: Run pylint
+        working-directory: engine
+        run: |
+          pylint src/clusterfactory_engine/ --disable=missing-docstring,too-few-public-methods || true
+
+      - name: Check imports
+        working-directory: engine
+        run: |
+          python -c "
+          from clusterfactory_engine import Credential, Component
+          from clusterfactory_engine.components import Gitea, Jenkins
+          print('✓ All imports successful')
+          "
+
+  build-wire-image:
+    name: Build wire engine Docker image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
+
+      - name: Build wire engine image
+        working-directory: engine
+        run: |
+          docker build -t clusterfactory/wire:test -f Dockerfile .
+          echo "✓ Wire engine image built successfully"
+
+      - name: Inspect image
+        run: |
+          docker inspect clusterfactory/wire:test
+          docker history clusterfactory/wire:test
+
+      - name: Test image runs
+        run: |
+          docker run --rm clusterfactory/wire:test python -c "from clusterfactory_engine import Credential; print('✓ Engine loads correctly')"
+
+  security-scan:
+    name: Security scan wire engine
+    runs-on: ubuntu-latest
+    needs: build-wire-image
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
+
+      - name: Build image for scanning
+        working-directory: engine
+        run: docker build -t clusterfactory/wire:scan -f Dockerfile .
+
+      - name: Run Trivy scan
+        uses: aquasecurity/trivy-action@0.29.0
+        with:
+          image-ref: 'clusterfactory/wire:scan'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+
+      - name: Upload Trivy results
+        uses: github/codeql-action/upload-sarif@7dd8b13b3f8e2f6468d89f4abe0c2d91e3801b0b  # v3.28.5
+        with:
+          sarif_file: 'trivy-results.sarif'
+        if: always()

--- a/.github/workflows/zarf-test.yaml
+++ b/.github/workflows/zarf-test.yaml
@@ -42,10 +42,22 @@ jobs:
         run: |
           pip install pyyaml jsonschema
 
+      - name: Check if Zarf files exist
+        id: check_files
+        run: |
+          if [ -f "zarf.yaml" ] && [ -f "validate-package.py" ]; then
+            echo "files_exist=true" >> $GITHUB_OUTPUT
+          else
+            echo "files_exist=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Zarf files not found - skipping validation (expected on non-v0.3 branches)"
+          fi
+
       - name: Validate package structure
+        if: steps.check_files.outputs.files_exist == 'true'
         run: python validate-package.py
 
       - name: Validate zarf.yaml syntax
+        if: steps.check_files.outputs.files_exist == 'true'
         run: |
           python -c "
           import yaml
@@ -59,6 +71,7 @@ jobs:
           "
 
       - name: Validate platform.yaml syntax
+        if: steps.check_files.outputs.files_exist == 'true'
         run: |
           python -c "
           import yaml
@@ -69,6 +82,7 @@ jobs:
           "
 
       - name: Check for required manifests
+        if: steps.check_files.outputs.files_exist == 'true'
         run: |
           for manifest in wire-job.yaml wire-rbac.yaml platform-configmap.yaml gitea-admin-secret.yaml networkpolicy.yaml; do
             if [ ! -f "manifests/$manifest" ]; then
@@ -105,23 +119,37 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Check if engine directory exists
+        id: check_engine
+        run: |
+          if [ -d "engine" ]; then
+            echo "engine_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "engine_exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Engine directory not found - skipping lint (expected on non-v0.3 branches)"
+          fi
+
       - name: Set up Python
+        if: steps.check_engine.outputs.engine_exists == 'true'
         uses: actions/setup-python@0b93645e9fea7318ecaed2b359559ac225c90a2b  # v5.3.0
         with:
           python-version: '3.12'
 
       - name: Install dependencies
+        if: steps.check_engine.outputs.engine_exists == 'true'
         working-directory: engine
         run: |
           pip install -e .
           pip install pylint
 
       - name: Run pylint
+        if: steps.check_engine.outputs.engine_exists == 'true'
         working-directory: engine
         run: |
           pylint src/clusterfactory_engine/ --disable=missing-docstring,too-few-public-methods || true
 
       - name: Check imports
+        if: steps.check_engine.outputs.engine_exists == 'true'
         working-directory: engine
         run: |
           python -c "
@@ -137,21 +165,35 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Check if engine directory exists
+        id: check_engine
+        run: |
+          if [ -d "engine" ]; then
+            echo "engine_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "engine_exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Engine directory not found - skipping build (expected on non-v0.3 branches)"
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check_engine.outputs.engine_exists == 'true'
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
 
       - name: Build wire engine image
+        if: steps.check_engine.outputs.engine_exists == 'true'
         working-directory: engine
         run: |
           docker build -t clusterfactory/wire:test -f Dockerfile .
           echo "✓ Wire engine image built successfully"
 
       - name: Inspect image
+        if: steps.check_engine.outputs.engine_exists == 'true'
         run: |
           docker inspect clusterfactory/wire:test
           docker history clusterfactory/wire:test
 
       - name: Test image runs
+        if: steps.check_engine.outputs.engine_exists == 'true'
         run: |
           docker run --rm clusterfactory/wire:test python -c "from clusterfactory_engine import Credential; print('✓ Engine loads correctly')"
 
@@ -163,14 +205,27 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
 
+      - name: Check if engine directory exists
+        id: check_engine
+        run: |
+          if [ -d "engine" ]; then
+            echo "engine_exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "engine_exists=false" >> $GITHUB_OUTPUT
+            echo "⚠️ Engine directory not found - skipping security scan (expected on non-v0.3 branches)"
+          fi
+
       - name: Set up Docker Buildx
+        if: steps.check_engine.outputs.engine_exists == 'true'
         uses: docker/setup-buildx-action@c47758b77c9736f4b2ef4073d4d51994fabfe349  # v3.7.1
 
       - name: Build image for scanning
+        if: steps.check_engine.outputs.engine_exists == 'true'
         working-directory: engine
         run: docker build -t clusterfactory/wire:scan -f Dockerfile .
 
       - name: Run Trivy scan
+        if: steps.check_engine.outputs.engine_exists == 'true'
         uses: aquasecurity/trivy-action@0.29.0
         with:
           image-ref: 'clusterfactory/wire:scan'
@@ -179,7 +234,7 @@ jobs:
           severity: 'CRITICAL,HIGH'
 
       - name: Upload Trivy results
+        if: steps.check_engine.outputs.engine_exists == 'true'
         uses: github/codeql-action/upload-sarif@7dd8b13b3f8e2f6468d89f4abe0c2d91e3801b0b  # v3.28.5
         with:
           sarif_file: 'trivy-results.sarif'
-        if: always()

--- a/.github/workflows/zarf-test.yaml
+++ b/.github/workflows/zarf-test.yaml
@@ -93,6 +93,7 @@ jobs:
           done
 
       - name: Validate Kubernetes manifests
+        if: steps.check_files.outputs.files_exist == 'true'
         run: |
           for manifest in manifests/*.yaml; do
             echo "Validating $manifest..."

--- a/.github/workflows/zarf-test.yaml
+++ b/.github/workflows/zarf-test.yaml
@@ -202,6 +202,7 @@ jobs:
     name: Security scan wire engine
     runs-on: ubuntu-latest
     needs: build-wire-image
+    if: success()
     steps:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
@@ -227,7 +228,7 @@ jobs:
 
       - name: Run Trivy scan
         if: steps.check_engine.outputs.engine_exists == 'true'
-        uses: aquasecurity/trivy-action@0.29.0
+        uses: aquasecurity/trivy-action@v0.36.0
         with:
           image-ref: 'clusterfactory/wire:scan'
           format: 'sarif'
@@ -236,6 +237,6 @@ jobs:
 
       - name: Upload Trivy results
         if: steps.check_engine.outputs.engine_exists == 'true'
-        uses: github/codeql-action/upload-sarif@7dd8b13b3f8e2f6468d89f4abe0c2d91e3801b0b  # v3.28.5
+        uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'


### PR DESCRIPTION
Add workflow to validate Zarf package changes in PRs.

## What this adds

New workflow that runs when Zarf-related files change:
- `zarf.yaml`, `platform.yaml`
- `manifests/**`
- `values/gitea.yaml`, `values/jenkins.yaml`
- `engine/**`

## Jobs

1. **validate-package** - Validate Zarf/platform YAML structure
2. **lint-wire-engine** - Lint Python code
3. **build-wire-image** - Build Docker image
4. **security-scan** - Trivy security scan

## Why needed

PR #43 (v0.3) introduces Zarf packaging but can't trigger tests because the workflow doesn't exist on main yet. This PR adds the workflow so #43 can run tests.

## Merge order

1. Merge this PR first
2. Then #43 will automatically run Zarf tests